### PR TITLE
Handle stale items_new tables in migrations

### DIFF
--- a/artiFACTSv11.1.py
+++ b/artiFACTSv11.1.py
@@ -752,9 +752,13 @@ def _ensure_tables():
             needs_rebuild = True
 
     if needs_rebuild:
+        # If a previous migration left behind a partial items_new, drop it so we
+        # can recreate the table with the correct schema (including new cols)
+        cur.execute("DROP TABLE IF EXISTS items_new")
+
         # Build the new table with the desired schema + unique constraint
         cur.execute("""
-            CREATE TABLE IF NOT EXISTS items_new (
+            CREATE TABLE items_new (
                 id INTEGER PRIMARY KEY,
                 name TEXT,
                 category TEXT,


### PR DESCRIPTION
## Summary
- Drop any existing `items_new` table before rebuilding schema so migrations always include new columns like `found_on`

## Testing
- `python -m py_compile artiFACTSv11.1.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1da76cf0c8322a6964287ea53e15b