### PR TITLE
Ensure item_details table has composite unique key

### DIFF
--- a/artiFACTSv11.1.py
+++ b/artiFACTSv11.1.py
@@ -720,6 +720,19 @@ def _ensure_tables():
         )
     """)
 
+    # Ensure auxiliary details table exists with composite unique key for upserts
+    cur.execute("""
+        CREATE TABLE IF NOT EXISTS item_details (
+            item_id INTEGER,
+            key TEXT,
+            value TEXT
+        )
+    """)
+    cur.execute("""
+        CREATE UNIQUE INDEX IF NOT EXISTS idx_item_details_item_key
+        ON item_details (item_id, key)
+    """)
+
     # Discover current columns on 'items'
     cur.execute("PRAGMA table_info(items)")
     old_cols = [r[1] for r in cur.fetchall()]


### PR DESCRIPTION
## Summary
- Create `item_details` table during startup and add unique index on `(item_id, key)` for upserts
- Keep `_ensure_tables()` called at import to initialize DB after nuking

## Testing
- `python -m py_compile artiFACTSv11.1.py`


------
https://chatgpt.com/codex/tasks/task_e_68a1ebdae11c8322a9923d1ed018a8cc