### PR TITLE
Ensure uploaded fossil images appear first

### DIFF
--- a/artiFACTSv13.py
+++ b/artiFACTSv13.py
@@ -10,6 +10,7 @@ import sqlite3
 import cv2
 import os
 import shutil
+import glob
 import tempfile
 import threading
 import base64
@@ -1476,16 +1477,20 @@ def populate_photo_slots(item_id: int, category: str, name: str, details: dict, 
         except Exception:
             pass
 
-        # promote the local copy to img1 if not already present
+        # promote the local copy to img1, replacing any existing first slot
         if cat in {"toy", "fossil", "shell", "mineral"}:
             dest_first = os.path.join(item_dir, f"img1{up_ext}")
-            if not os.path.exists(dest_first):
-                try:
-                    shutil.copyfile(up_dest, dest_first)
-                    meta["img1_path"] = dest_first
-                    meta["img1_src"] = "uploaded"
-                except Exception:
-                    pass
+            try:
+                for f in glob.glob(os.path.join(item_dir, "img1.*")):
+                    try:
+                        os.remove(f)
+                    except Exception:
+                        pass
+                shutil.copyfile(up_dest, dest_first)
+                meta["img1_path"] = dest_first
+                meta["img1_src"] = "uploaded"
+            except Exception:
+                pass
             # next web save goes to slot 2
             slot = 2
 


### PR DESCRIPTION
## Summary
- Replace existing first-slot image with uploaded photo for fossils, shells, minerals, and toys
- Clean up any previous img1 files and import `glob` for file handling

## Testing
- `python -m py_compile artiFACTSv13.py`


------
https://chatgpt.com/codex/tasks/task_e_68a231faeb308322b1685fabb3bb61a2