### PR TITLE
Ensure uploaded card images appear first in library

### DIFF
--- a/artiFACTSv13.py
+++ b/artiFACTSv13.py
@@ -1478,7 +1478,7 @@ def populate_photo_slots(item_id: int, category: str, name: str, details: dict, 
             pass
 
         # promote the local copy to img1, replacing any existing first slot
-        if cat in {"toy", "fossil", "shell", "mineral"}:
+        if cat in {"toy", "card", "fossil", "shell", "mineral"}:
             dest_first = os.path.join(item_dir, f"img1{up_ext}")
             try:
                 for f in glob.glob(os.path.join(item_dir, "img1.*")):


### PR DESCRIPTION
## Summary
- Promote uploaded images for card items to slot 1 so library records show user photos first.

## Testing
- `python -m py_compile artiFACTSv13.py`


------
https://chatgpt.com/codex/tasks/task_e_68a2378640708322af1b70aab9f6e5d7