### PR TITLE
Inherit blurb canvas background from parent

### DIFF
--- a/artiFACTSv15.py
+++ b/artiFACTSv15.py
@@ -2251,7 +2251,11 @@ class LibraryWindow(tk.Toplevel):
             return
             
         try:
-            bubble = tk.Canvas(self.image_canvas, bg='', highlightthickness=0)
+            bubble = tk.Canvas(
+                self.image_canvas,
+                bg=self.image_canvas.cget('bg'),   # inherit parent bg; valid color name
+                highlightthickness=0
+            )
             pad = 8
             max_w = 220
 


### PR DESCRIPTION
## Summary
- Avoid empty background colors by letting the blurb canvas inherit its parent's background

## Testing
- `python -m py_compile artiFACTSv15.py`


------
https://chatgpt.com/codex/tasks/task_e_68ab3835ace08322891ae474488d25d0